### PR TITLE
Always retry alternatives install states

### DIFF
--- a/webstorm/linuxenv.sls
+++ b/webstorm/linuxenv.sls
@@ -31,6 +31,9 @@ webstorm-home-alt-install:
     - link: '{{ webstorm.jetbrains.home }}/webstorm'
     - path: '{{ webstorm.jetbrains.realhome }}'
     - priority: {{ webstorm.linux.altpriority }}
+    - retry:
+        attempts: 3
+        until: True
 
 webstorm-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ webstorm-home-alt-set:
     - path: {{ webstorm.jetbrains.realhome }}
     - onchanges:
       - alternatives: webstorm-home-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
 # Add to alternatives system
 webstorm-alt-install:
@@ -49,6 +55,9 @@ webstorm-alt-install:
     - require:
       - alternatives: webstorm-home-alt-install
       - alternatives: webstorm-home-alt-set
+    - retry:
+        attempts: 3
+        until: True
 
 webstorm-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ webstorm-alt-set:
     - path: {{ webstorm.jetbrains.realcmd }}
     - onchanges:
       - alternatives: webstorm-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
   {% endif %}
 

--- a/webstorm/map.jinja
+++ b/webstorm/map.jinja
@@ -22,7 +22,8 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
+{%- set pcode = ide.jetbrains.product %}
+{%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
 {% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None',) %}
    {%- set pcode = ide.jetbrains.product %}
 {% endif %}


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` always fails on 1st run.

Verified on SuSE